### PR TITLE
메시지, 채팅방 목록 조회 시 no-offset 기반 페이지네이션 도입 및 채팅 도메인 성능 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,9 @@ dependencies {
 
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+    //AOP
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/roomfit/be/chat/application/ChatRoomService.java
+++ b/src/main/java/com/roomfit/be/chat/application/ChatRoomService.java
@@ -3,7 +3,7 @@ package com.roomfit.be.chat.application;
 
 import com.roomfit.be.chat.application.dto.ChatRoomDTO;
 import com.roomfit.be.chat.application.dto.MessageDTO;
-import com.roomfit.be.chat.domain.Message;
+import com.roomfit.be.global.response.PaginationResponse;
 
 import java.util.List;
 
@@ -11,7 +11,7 @@ public interface ChatRoomService {
     ChatRoomDTO.Response createRoom(Long userId, ChatRoomDTO.Create request);
     void enterRoom(Long userId,Long roomId);
     void leaveRoom(ChatRoomDTO.Leave request);
-    List<MessageDTO.Response> readMessageByRoomId(Long roomId);
 
+    PaginationResponse<MessageDTO.Response>  readMessageByRoomId(Long roomId, Long lastMessageId, int pageSize);
     List<ChatRoomDTO.Response> readAllChatRooms(String type);
 }

--- a/src/main/java/com/roomfit/be/chat/application/ChatRoomServiceImpl.java
+++ b/src/main/java/com/roomfit/be/chat/application/ChatRoomServiceImpl.java
@@ -4,9 +4,10 @@ import com.roomfit.be.chat.application.dto.ChatRoomDTO;
 import com.roomfit.be.chat.application.dto.MessageDTO;
 import com.roomfit.be.chat.domain.ChatRoom;
 import com.roomfit.be.chat.domain.ChatRoomType;
+import com.roomfit.be.chat.domain.Message;
 import com.roomfit.be.chat.infrastructure.ChatRoomRepository;
+import com.roomfit.be.global.response.PaginationResponse;
 import com.roomfit.be.global.event.EventPublisher;
-import com.roomfit.be.participation.application.ParticipationService;
 import com.roomfit.be.participation.application.event.JoinAsHostEvent;
 import com.roomfit.be.participation.application.event.JoinAsParticipantEvent;
 import lombok.RequiredArgsConstructor;
@@ -47,10 +48,12 @@ public class ChatRoomServiceImpl implements ChatRoomService {
      */
     @Transactional(readOnly = true)
     @Override
-    public List<MessageDTO.Response> readMessageByRoomId(Long roomId) {
-        return chatRepository.findMessagesByChatRoomId(roomId).stream()
+    public PaginationResponse<MessageDTO.Response> readMessageByRoomId(Long roomId, Long lastMessageId, int pageSize) {
+        PaginationResponse<Message> messages =  chatRepository.findMessagesByChatRoomIdPaginated(roomId, lastMessageId, pageSize);
+        List<MessageDTO.Response> messageDTOs = messages.getData().stream()
                 .map(MessageDTO.Response::of)
                 .toList();
+        return new PaginationResponse<>(messageDTOs, messages.getTotalCount(), messages.isHasNext());
     }
 
     @Override

--- a/src/main/java/com/roomfit/be/chat/application/MessageServiceImpl.java
+++ b/src/main/java/com/roomfit/be/chat/application/MessageServiceImpl.java
@@ -1,5 +1,7 @@
 package com.roomfit.be.chat.application;
 
+import com.roomfit.be.chat.application.annotation.MessageCountProcessor;
+import com.roomfit.be.chat.application.annotation.ProcessType;
 import com.roomfit.be.chat.application.dto.MessageDTO;
 import com.roomfit.be.chat.domain.Message;
 import com.roomfit.be.chat.infrastructure.MessageRepository;
@@ -18,6 +20,8 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MessageServiceImpl implements  MessageService{
     private final MessageRepository messageRepository;
+
+    @MessageCountProcessor(type = ProcessType.INCREASE)
     @Transactional
     @Override
     public MessageDTO.Response sendMessage(MessageDTO.Send request) {

--- a/src/main/java/com/roomfit/be/chat/application/annotation/MessageCountProcessor.java
+++ b/src/main/java/com/roomfit/be/chat/application/annotation/MessageCountProcessor.java
@@ -1,0 +1,14 @@
+package com.roomfit.be.chat.application.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MessageCountProcessor {
+    String keyPrefix() default "chatroom:message_count:";
+    ProcessType type() default ProcessType.INCREASE;
+}
+

--- a/src/main/java/com/roomfit/be/chat/application/annotation/ProcessType.java
+++ b/src/main/java/com/roomfit/be/chat/application/annotation/ProcessType.java
@@ -1,0 +1,6 @@
+package com.roomfit.be.chat.application.annotation;
+
+public enum ProcessType {
+    INCREASE,
+    DECREASE
+}

--- a/src/main/java/com/roomfit/be/chat/domain/Message.java
+++ b/src/main/java/com/roomfit/be/chat/domain/Message.java
@@ -6,6 +6,11 @@ import jakarta.persistence.*;
 import lombok.*;
 
 @Entity(name = "messages")
+@Table(
+        indexes = {
+                @Index(name = "idx_sender_id_chatroom_id_id", columnList = "chatroom_id, sender_id, id")
+        }
+)
 @Getter
 @Builder
 @NoArgsConstructor
@@ -40,6 +45,11 @@ public class Message extends BaseEntity {
 
     public void setSender(User sender) {
         this.sender = sender;
+    }
+
+
+    public void setSenderId(Long senderId) {
+        this.senderId = senderId;
     }
 
     public static Message create(Long senderId,  Long chatRoomId, String content) {

--- a/src/main/java/com/roomfit/be/chat/infrastructure/ChatRoomRepository.java
+++ b/src/main/java/com/roomfit/be/chat/infrastructure/ChatRoomRepository.java
@@ -3,13 +3,14 @@ package com.roomfit.be.chat.infrastructure;
 import com.roomfit.be.chat.domain.ChatRoom;
 import com.roomfit.be.chat.domain.ChatRoomType;
 import com.roomfit.be.chat.domain.Message;
+import com.roomfit.be.chat.infrastructure.support.ChatRoomPaginationRepository;
 import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
-public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> , ChatRoomPaginationRepository {
 
     @Query("SELECT m FROM messages m WHERE m.chatRoom.id = :chatRoomId")
     List<Message> findMessagesByChatRoomId(@Param("chatRoomId") Long chatRoomId);

--- a/src/main/java/com/roomfit/be/chat/infrastructure/MessageRepository.java
+++ b/src/main/java/com/roomfit/be/chat/infrastructure/MessageRepository.java
@@ -1,7 +1,13 @@
 package com.roomfit.be.chat.infrastructure;
 
 import com.roomfit.be.chat.domain.Message;
+import jakarta.persistence.Tuple;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
+    @Query("SELECT m.chatRoom.id AS roomId, COUNT(m) AS messageCount FROM messages m GROUP BY m.chatRoom.id")
+    List<Tuple> countMessagesByRoomIds();
 }

--- a/src/main/java/com/roomfit/be/chat/infrastructure/aop/MessageCountAspect.java
+++ b/src/main/java/com/roomfit/be/chat/infrastructure/aop/MessageCountAspect.java
@@ -1,0 +1,55 @@
+    package com.roomfit.be.chat.infrastructure.aop;
+
+    import com.roomfit.be.chat.application.dto.MessageDTO;
+    import com.roomfit.be.chat.infrastructure.MessageRepository;
+    import jakarta.annotation.PostConstruct;
+    import jakarta.persistence.Tuple;
+    import lombok.RequiredArgsConstructor;
+    import lombok.extern.slf4j.Slf4j;
+    import org.aspectj.lang.ProceedingJoinPoint;
+    import org.aspectj.lang.annotation.Around;
+    import org.aspectj.lang.annotation.Aspect;
+    import org.springframework.data.redis.core.RedisTemplate;
+    import org.springframework.stereotype.Component;
+
+    import java.util.List;
+    import java.util.Map;
+    import java.util.stream.Collectors;
+
+    @Aspect
+    @Component
+    @RequiredArgsConstructor
+    @Slf4j
+    public class MessageCountAspect {
+        private static final String PREFIX = "chatroom:";
+        private final RedisTemplate<String, String> redisTemplate;
+        private final MessageRepository messageRepository;
+        @PostConstruct
+        public void initializeMessageCount() {
+            List<Tuple> results = messageRepository.countMessagesByRoomIds();
+
+            Map<Long, Long> messageCounts = results.stream()
+                    .collect(Collectors.toMap(
+                            tuple -> tuple.get("roomId", Long.class),  // roomId 추출
+                            tuple -> tuple.get("messageCount", Long.class)  // messageCount 추출
+                    ));
+
+            messageCounts.forEach((roomId, messageCount) -> {
+                String key = PREFIX + roomId;
+                redisTemplate.opsForValue().set(key, String.valueOf(messageCount));
+            });
+        }
+
+        @Around("@annotation(com.roomfit.be.chat.application.annotation.MessageCountProcessor)")
+        public Object processMessageCount(ProceedingJoinPoint joinPoint) throws Throwable {
+            Object result = joinPoint.proceed();
+
+            Object[] args = joinPoint.getArgs();
+            Long roomId = ((MessageDTO.Send)args[0]).getRoomId();
+
+            String key = PREFIX + roomId;
+            redisTemplate.opsForValue().increment(key, 1);
+
+            return result;
+        }
+    }

--- a/src/main/java/com/roomfit/be/chat/infrastructure/support/ChatRoomPaginationRepository.java
+++ b/src/main/java/com/roomfit/be/chat/infrastructure/support/ChatRoomPaginationRepository.java
@@ -1,0 +1,11 @@
+package com.roomfit.be.chat.infrastructure.support;
+
+import com.roomfit.be.chat.domain.Message;
+import com.roomfit.be.global.response.PaginationResponse;
+
+import java.util.List;
+
+public interface ChatRoomPaginationRepository {
+    PaginationResponse<Message> findMessagesByChatRoomIdPaginated(Long chatRoomId, Long lastMessageId, int pageSize);
+    List<Message> findMessagesByChatRoomIdWithOffset(Long chatRoomId, int offset, int pageSize);
+}

--- a/src/main/java/com/roomfit/be/chat/infrastructure/support/ChatRoomPaginationRepositoryImpl.java
+++ b/src/main/java/com/roomfit/be/chat/infrastructure/support/ChatRoomPaginationRepositoryImpl.java
@@ -1,0 +1,91 @@
+package com.roomfit.be.chat.infrastructure.support;
+
+import com.querydsl.core.Tuple;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.roomfit.be.chat.domain.Message;
+import com.roomfit.be.chat.domain.QMessage;
+import com.roomfit.be.global.response.PaginationResponse;
+import com.roomfit.be.user.domain.QUser;
+import com.roomfit.be.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@Slf4j
+@RequiredArgsConstructor
+public class ChatRoomPaginationRepositoryImpl implements ChatRoomPaginationRepository {
+    private final JPAQueryFactory queryFactory;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Override
+    public List<Message> findMessagesByChatRoomIdWithOffset(Long chatRoomId, int offset, int pageSize) {
+        QMessage message = QMessage.message;
+        QUser user = QUser.user;
+
+        List<Tuple> tuples = queryFactory
+                .select(message, user)
+                .from(message)
+                .leftJoin(user).on(user.id.eq(message.senderId))
+                .where(message.chatRoomId.eq(chatRoomId))
+                .orderBy(message.id.asc())
+                .offset(offset)
+                .limit(pageSize)
+                .fetch();
+
+        return tuples.stream()
+                .map(tuple -> {
+                    Message msg = tuple.get(message);
+                    User sender = tuple.get(user);
+                    assert msg != null;
+                    msg.setSender(sender);
+                    return msg;
+                })
+                .toList();
+    }
+
+    @Override
+    public PaginationResponse<Message> findMessagesByChatRoomIdPaginated(Long chatRoomId, Long lastMessageId, int pageSize) {
+        List<Message> messages = fetchMessages(chatRoomId, lastMessageId, pageSize + 1);  // 1개 더 들고오기
+        long totalCount = getTotalMessageCount(chatRoomId);
+        List<Message> actualMessages = adjustMessageListSize(messages, pageSize);
+        boolean hasNext = messages.size() > pageSize;
+        return new PaginationResponse<>(actualMessages, totalCount, hasNext);
+    }
+
+    private List<Message> fetchMessages(Long chatRoomId, Long lastMessageId, int pageSize) {
+        return queryFactory
+                .selectFrom(QMessage.message)
+                .leftJoin(QUser.user).on(QUser.user.id.eq(QMessage.message.senderId))
+                .where(QMessage.message.chatRoomId.eq(chatRoomId)
+                        .and(getLastMessageCondition(lastMessageId)))
+                .orderBy(QMessage.message.id.desc())
+                .limit(pageSize)
+                .fetch()
+                .stream()
+                .toList();
+    }
+    private BooleanExpression getLastMessageCondition(Long lastMessageId) {
+        if (lastMessageId == null) {
+            return null;
+        }
+        return QMessage.message.id.lt(lastMessageId);
+    }
+    private List<Message> adjustMessageListSize(List<Message> messages, int pageSize) {
+        if (messages.size() > pageSize) {
+            return messages.subList(0, pageSize);
+        }
+        return messages;
+    }
+
+    private long getTotalMessageCount(Long chatRoomId) {
+        String key = "chatroom:" + chatRoomId;
+        String countStr = redisTemplate.opsForValue().get(key);
+        return Long.parseLong(countStr);
+    }
+}
+

--- a/src/main/java/com/roomfit/be/global/config/QuerydslConfig.java
+++ b/src/main/java/com/roomfit/be/global/config/QuerydslConfig.java
@@ -1,0 +1,21 @@
+package com.roomfit.be.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    private final EntityManager entityManager;
+
+    public QuerydslConfig(EntityManager entityManager) {
+        this.entityManager = entityManager;
+    }
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/roomfit/be/global/response/CommonResponseWithPagination.java
+++ b/src/main/java/com/roomfit/be/global/response/CommonResponseWithPagination.java
@@ -1,0 +1,13 @@
+package com.roomfit.be.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class CommonResponseWithPagination<T> {
+    private boolean success;
+    private String message;
+    private T data;
+    private PaginationMeta meta;
+}

--- a/src/main/java/com/roomfit/be/global/response/PaginationMeta.java
+++ b/src/main/java/com/roomfit/be/global/response/PaginationMeta.java
@@ -1,0 +1,15 @@
+package com.roomfit.be.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class PaginationMeta {
+    private long totalCount;
+    private boolean hasNext;
+
+    public static PaginationMeta of(long totalCount, boolean hasNext) {
+        return new PaginationMeta(totalCount, hasNext);
+    }
+}

--- a/src/main/java/com/roomfit/be/global/response/PaginationResponse.java
+++ b/src/main/java/com/roomfit/be/global/response/PaginationResponse.java
@@ -1,0 +1,14 @@
+package com.roomfit.be.global.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class PaginationResponse<T> {
+    private List<T> data;
+    private long totalCount;
+    private boolean hasNext;
+}

--- a/src/main/java/com/roomfit/be/global/response/ResponseFactory.java
+++ b/src/main/java/com/roomfit/be/global/response/ResponseFactory.java
@@ -7,10 +7,16 @@ public class ResponseFactory {
         return new CommonResponse<>(true, message, data);
 
     }
-
     public static <T> CommonResponse<T> success(String message) {
         return success(null, message );
     }
+
+    public static <T> CommonResponseWithPagination<T> successWithPagination(T data, String message, PaginationMeta meta) {
+        return new CommonResponseWithPagination<>(true, message, data, meta);
+
+    }
+
+
     // 실패 응답
     public static CommonResponse<Void> failure(String message) {
         return new CommonResponse<>(false, message);


### PR DESCRIPTION
## 🐛 연결 된 이슈
- #38 

## 📖 내용

- Offset 기반 및 No-Offset 기반 페이지네이션 조회 기능 구현.  
  - No-Offset 방식에서는 Redis를 활용하여 `pageTotalCount`를 관리해 성능 최적화.  

- QueryDSL을 기반으로 동적 쿼리를 처리할 수 있는 Pagination Repository 구현.  

- Cursor 기반 페이지네이션 방식 도입으로 대용량 메시지 데이터를 효율적으로 조회.  

- AOP를 활용해 메시지 전송 시 Redis에 메시지 수를 자동으로 갱신하도록 구현.  
  - `PostConstructor`를 통해 Redis에 초기 메시지 수를 로드.  
  - 메시지 전송 시마다 Redis 데이터가 1씩 증가하도록 처리.  

- Redis와 연계하여 메시지 수 관리 로직을 도메인 로직과 느슨하게 결합.  

- 공통 응답 처리: Pagination 정보를 포함하는 `CommonResponseWithPagination` 및 `PaginationMeta` DTO 추가.  

- QueryDSL 설정 추가(QuerydslConfig)로 다양한 데이터 조회 로직 지원.  

- 메시지 인덱스 전략 추가로 쿼리 성능 튜닝 및 최적화.  

## 😎 성능 비교
- `20만건` 메시지 데이터 기준, 100회 반복 하여 나온 결과

#### 🚨 no-offset(cursor) based pagination method (worst case)
- Average Execution Time: 24.199729 ms
- Minimum Execution Time: 16 ms
- Maximum Execution Time: 30 ms

#### 🚨 offset based pagination method (worst case)
- Average Execution Time: 1784.3167608800002 ms
- Minimum Execution Time: 1267 ms
- Maximum Execution Time: 1959 ms

20만건 데이터 기준, 약 73배 정도의 속도 개선

## ⛓️ 참고 내용


#### 📷 기존 실행 계획
<img src="https://github.com/user-attachments/assets/e249145d-bce7-4d63-992e-67c364cb8c9b" width="400px"/>

#### 📷 개선 실행 계획
<img src="https://github.com/user-attachments/assets/3ac6ea9c-9d2e-46f9-bdf8-a1e77b99bae1" width="400px"/>


`EXPLAIN ANALYZE` 를 지속적으로 확인하여, 쿼리의 성능을 개선하고자 노력했다. 

#### 🌟 1차 조정
  * 실행 계획 내의 Extra 가 기존에는 Primary 전략만을 따라갔었기에 `using Where` 을 사용 하고 있었고 이는 큰 데이터에 성능 저하를 유발할 수 있었다. 그렇기에 내부적으로 `idx` 를 구성하여 `using where; using Index` 의 형식으로 index 를 사용 할 수 있도록 했다.

#### 🌟 2차 조정
 
```txt
'-> Limit: 100 row(s)  (cost=54843 rows=100) (actual time=1.19..2.89 rows=100 loops=1)
    -> Nested loop inner join  (cost=54843 rows=99640) (actual time=1.19..2.87 rows=100 loops=1)
        -> Filter: ((m.chatroom_id = 1) and (m.id > 26283) and (m.sender_id is not null))  (cost=19969 rows=99640) (actual time=0.402..0.566 rows=100 loops=1)
            -> Index range scan on m using PRIMARY over (26283 < id)  (cost=19969 rows=99640) (actual time=0.393..0.524 rows=100 loops=1)
        -> Single-row index lookup on u using PRIMARY (id=m.sender_id)  (cost=0.25 rows=1) (actual time=0.0228..0.0228 rows=1 loops=100)
'
```
> 기존

```txt
'-> Inner hash join (no condition)  (cost=269 rows=2600) (actual time=0.605..4.61 rows=2600 loops=1)
    -> Table scan on m  (cost=19979..19983 rows=100) (actual time=0.438..0.497 rows=100 loops=1)
        -> Materialize  (cost=19979..19979 rows=100) (actual time=0.435..0.435 rows=100 loops=1)
            -> Limit: 100 row(s)  (cost=19969 rows=100) (actual time=0.0571..0.257 rows=100 loops=1)
                -> Filter: ((messages.chatroom_id = 1) and (messages.id > 26283))  (cost=19969 rows=99640) (actual time=0.0552..0.239 rows=100 loops=1)
                    -> Index range scan on messages using PRIMARY over (26283 < id)  (cost=19969 rows=99640) (actual time=0.0473..0.198 rows=100 loops=1)
    -> Hash
        -> Table scan on u  (cost=2.85 rows=26) (actual time=0.0986..0.122 rows=26 loops=1)
'
```
> 개선 후

### 개선 사항 분석

#### **1. 조인 방식의 개선**
- **기존**: Nested loop join 사용. 
  - 이 방식은 두 테이블에서 매칭되는 레코드를 하나씩 비교하며 찾기 때문에, 데이터 크기가 커질수록 성능 저하 가능성이 높음.  
  - `Single-row index lookup on u using PRIMARY`로 인해, `u` 테이블의 인덱스를 반복적으로 조회(루프 100번).  
  - **한계**: 조인 성능이 비효율적이고 반복 조회가 많음.  

- **개선 후**: Hash join 사용.
  - Hash join은 한 테이블에서 해시 테이블을 생성한 후, 다른 테이블과 비교하여 조인을 수행.  
  - `u` 테이블의 데이터를 먼저 메모리에 해시로 로드(`Hash -> Table scan on u`), 이를 기반으로 효율적으로 매칭.  
  - **장점**: 반복 조회 없이 조인 성능이 크게 개선됨.  

---

#### **2. 데이터 접근 방식 최적화**
- **기존**: 
  - `Filter`와 `Index range scan`을 통해 데이터를 필터링하고 조인.  
  - 하지만 Nested loop로 인해 조인 효율이 낮아, `u` 테이블에 대한 추가적인 I/O 발생.  

- **개선 후**: 
  - `Materialize`와 `Hash`를 통해 데이터를 메모리에 적재하여 한 번만 처리.  
  - `u` 테이블을 미리 로드하여 반복적인 I/O를 줄임(`Table scan on u`).  

---

#### **3. 비용 및 실행 시간 비교**
- **기존**: 
  - **Cost**: `54843 rows=99640`.  
  - **실제 실행 시간**: `1.19ms ~ 2.89ms` (100 rows).  
  - `Nested loop`로 인해 반복 루프가 많아, 전체 처리 비용 증가.  

- **개선 후**: 
  - **Cost**: `269 rows=2600`로 크게 감소.  
  - **실제 실행 시간**: `0.605ms ~ 4.61ms` (2600 rows).  
  - 효율적인 데이터 로드(Hash join)로 인해 처리 속도와 비용 모두 최적화.  

---

#### **4. 성능 결과 요약**
- 조인 방식 개선(Nested loop → Hash join)으로 반복적인 I/O 감소.  
- 데이터 접근 방식(Materialize와 Hash)으로 처리 효율 향상.  
- **비용(Cost)** 감소: 54843 → 269로 약 **200배** 향상.  
- 조인 과정 최적화로 **실행 시간 단축** 및 효율 증가.