### PR TITLE
비동기 싱크 문제 해결 및 ChatRoom-Participation 관계 개선

### DIFF
--- a/src/main/java/com/roomfit/be/chat/application/ChatRoomServiceImpl.java
+++ b/src/main/java/com/roomfit/be/chat/application/ChatRoomServiceImpl.java
@@ -18,6 +18,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class ChatRoomServiceImpl implements ChatRoomService {
 
     private final ChatRoomRepository chatRepository;

--- a/src/main/java/com/roomfit/be/chat/domain/ChatRoom.java
+++ b/src/main/java/com/roomfit/be/chat/domain/ChatRoom.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -37,14 +38,18 @@ public class ChatRoom extends BaseEntity {
 
     Integer maxQuota;
 
-    @Builder.Default
-    Integer currentQuota = DEFAULT_QUOTA;
-
     String dormitory;
 
 
-    @OneToMany()
-    List<Participation> participationList;
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "chatRoom")
+    @Builder.Default
+    private List<Participation> participationList = new ArrayList<>();
+    public Integer getCurrentQuota() {
+        if(participationList != null){
+            return participationList.size();
+        }
+        return 0;
+    }
 
     public static ChatRoom createPrivateRoom(String name){
         return ChatRoom.builder()

--- a/src/main/java/com/roomfit/be/participation/application/ParticipationService.java
+++ b/src/main/java/com/roomfit/be/participation/application/ParticipationService.java
@@ -1,6 +1,8 @@
 package com.roomfit.be.participation.application;
 
+import com.roomfit.be.chat.application.dto.ChatRoomDTO;
 import com.roomfit.be.chat.domain.ChatRoom;
+import com.roomfit.be.participation.application.dto.ParticipantDTO;
 import com.roomfit.be.user.domain.User;
 
 import java.util.List;
@@ -8,6 +10,7 @@ import java.util.List;
 public interface ParticipationService {
     void joinAsHost(Long userId, Long chatRoomId);
     void joinAsParticipant(Long userId, Long chatRoomId);
+    List<ParticipantDTO> readParticipantsInChatRoom(Long roomId);
 //    void removeParticipant(Long userId, Long chatRoomId);
-    List<User> readParticipantsByRoomId(Long roomId);
+//    List<User> readParticipantsByRoomId(Long roomId);
 }

--- a/src/main/java/com/roomfit/be/participation/application/ParticipationServiceImpl.java
+++ b/src/main/java/com/roomfit/be/participation/application/ParticipationServiceImpl.java
@@ -1,13 +1,16 @@
 package com.roomfit.be.participation.application;
 
+import com.roomfit.be.chat.application.dto.ChatRoomDTO;
 import com.roomfit.be.chat.domain.ChatRoom;
 import com.roomfit.be.chat.infrastructure.ChatRoomRepository;
+import com.roomfit.be.participation.application.dto.ParticipantDTO;
 import com.roomfit.be.participation.domain.Participation;
 import com.roomfit.be.participation.infrastructure.ParticipationRepository;
 import com.roomfit.be.user.domain.User;
 import com.roomfit.be.user.infrastructure.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -18,30 +21,35 @@ public class ParticipationServiceImpl implements  ParticipationService{
     private final UserRepository userRepository;
     private final ChatRoomRepository chatRoomRepository;
 
+    @Transactional
     @Override
     public void joinAsHost(Long userId, Long chatRoomId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
-
         Participation participation = Participation.participateAsHost(user, chatRoom);
         participationRepository.save(participation);
     }
 
+    @Transactional
     @Override
     public void joinAsParticipant(Long userId, Long chatRoomId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
         ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId)
                 .orElseThrow(() -> new IllegalArgumentException("채팅방을 찾을 수 없습니다."));
-        
+
         Participation participation = Participation.participateAsParticipant(user, chatRoom);
         participationRepository.save(participation);
     }
 
     @Override
-    public List<User> readParticipantsByRoomId(Long roomId){
-        return participationRepository.findUsersByChatRoomId(roomId);
+    public List<ParticipantDTO> readParticipantsInChatRoom(Long roomId) {
+        return participationRepository.findUsersByChatRoomId(roomId)
+                .stream()
+                .map(ParticipantDTO::of)
+                .toList();
     }
+
 }

--- a/src/main/java/com/roomfit/be/participation/application/dto/ParticipantDTO.java
+++ b/src/main/java/com/roomfit/be/participation/application/dto/ParticipantDTO.java
@@ -1,0 +1,24 @@
+package com.roomfit.be.participation.application.dto;
+
+import com.roomfit.be.user.domain.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ParticipantDTO {
+    private Long id;
+    private String nickname;
+    private String college;
+    public static ParticipantDTO of(User participant){
+        return ParticipantDTO.builder()
+                .id(participant.getId())
+                .nickname(participant.getNickname())
+                .college(participant.getCollege())
+                .build();
+    }
+}

--- a/src/main/java/com/roomfit/be/participation/domain/Participation.java
+++ b/src/main/java/com/roomfit/be/participation/domain/Participation.java
@@ -30,18 +30,22 @@ public class Participation {
     private ParticipationType type;
 
     public static Participation participateAsHost(User user, ChatRoom chatRoom) {
-        return Participation.builder()
+        Participation participation = Participation.builder()
                 .user(user)
                 .chatRoom(chatRoom)
                 .type(ParticipationType.HOST)
                 .build();
+        chatRoom.getParticipationList().add(participation);
+        return participation;
     }
 
     public static Participation participateAsParticipant(User user, ChatRoom chatRoom) {
-        return Participation.builder()
+        Participation participation = Participation.builder()
                 .user(user)
                 .chatRoom(chatRoom)
                 .type(ParticipationType.PARTICIPANT)
                 .build();
+        chatRoom.getParticipationList().add(participation);
+        return participation;
     }
 }

--- a/src/main/java/com/roomfit/be/participation/presentation/ParticipationEventListener.java
+++ b/src/main/java/com/roomfit/be/participation/presentation/ParticipationEventListener.java
@@ -17,13 +17,11 @@ public class ParticipationEventListener {
     private final ParticipationService participationService;
 
     @EventListener
-    @Async("taskExecutor")
     public void onJoinAsHostHandler(JoinAsHostEvent event){
         participationService.joinAsHost(event.getUserId(),  event.getChatRoomId());
     }
 
     @EventListener
-    @Async("taskExecutor")
     public void onJoinAsParticipantHandler(JoinAsParticipantEvent event){
         participationService.joinAsParticipant(event.getUserId(),  event.getChatRoomId());
     }


### PR DESCRIPTION
## 🐛 연결 된 이슈
- #59 
- #58 
- #35 

## 📖 내용
- **ChatRoom-Participation 관계 매핑 개선**
  - `Participation` 도메인에서 `ChatRoom`과의 관계 매핑을 강화하여 양방향 연관관계 처리
  - `Participation` 생성 시, `chatRoom.getParticipationList().add(participation)`을 통해 연관관계 자동 업데이트

- **`currentQuota` 필드 제거**
  - `ChatRoom` 도메인 내 `currentQuota` 필드를 제거하고, `ParticipationList.size()`로 인원 수 계산

- **Lazy Loading 초기화 문제 해결**
  - 트랜잭션 범위 리팩토링을 통해 Lazy Loading 초기화 문제를 해결

- **DTO 최적화**
  - `ParticipantDTO`를 구성하여 응답 데이터 구조 최적화
  - `ParticipationService`에서 트랜잭션 범위 재설정 및 성능 개선

- **비동기 처리 수정**
  - `ParticipationEventListener`에서 `@Async` 어노테이션 제거
  - 비동기 처리로 인한 싱크 문제 해결
