### PR TITLE
핏글 조회하기 API와 채팅방 속한 사용자 조회API 합쳐서 채팅방 상세정보 API 추가 요청

### DIFF
--- a/src/main/java/com/roomfit/be/chat/application/ChatRoomService.java
+++ b/src/main/java/com/roomfit/be/chat/application/ChatRoomService.java
@@ -14,4 +14,5 @@ public interface ChatRoomService {
 
     PaginationResponse<MessageDTO.Response>  readMessageByRoomId(Long roomId, Long lastMessageId, int pageSize);
     List<ChatRoomDTO.Response> readAllChatRooms(String type);
+    ChatRoomDTO.DetailsResponse readChatRoomDetails(Long roomId);
 }

--- a/src/main/java/com/roomfit/be/chat/application/ChatRoomServiceImpl.java
+++ b/src/main/java/com/roomfit/be/chat/application/ChatRoomServiceImpl.java
@@ -8,6 +8,8 @@ import com.roomfit.be.chat.domain.Message;
 import com.roomfit.be.chat.infrastructure.ChatRoomRepository;
 import com.roomfit.be.global.response.PaginationResponse;
 import com.roomfit.be.global.event.EventPublisher;
+import com.roomfit.be.participation.application.ParticipationService;
+import com.roomfit.be.participation.application.dto.ParticipantDTO;
 import com.roomfit.be.participation.application.event.JoinAsHostEvent;
 import com.roomfit.be.participation.application.event.JoinAsParticipantEvent;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,7 @@ import java.util.List;
 public class ChatRoomServiceImpl implements ChatRoomService {
 
     private final ChatRoomRepository chatRepository;
+    private final ParticipationService participationService;
     private final EventPublisher eventPublisher;
     @Override
     public ChatRoomDTO.Response createRoom(Long userId, ChatRoomDTO.Create request) {
@@ -65,6 +68,13 @@ public class ChatRoomServiceImpl implements ChatRoomService {
                 .toList();
     }
 
+    public ChatRoomDTO.DetailsResponse readChatRoomDetails(Long roomId){
+        ChatRoom chatRoom = chatRepository.findById(roomId)
+                .orElseThrow();
+        List<ParticipantDTO> participants = participationService.readParticipantsInChatRoom(roomId);
+
+        return ChatRoomDTO.DetailsResponse.of(chatRoom, participants);
+    }
     private ChatRoom createGroupRoom(ChatRoomDTO.Create request){
         return ChatRoom.createGroupRoom(request.getName(), request.getDescription(), request.getDormitory(), request.getMaxQuota());
     }

--- a/src/main/java/com/roomfit/be/chat/application/dto/ChatRoomDTO.java
+++ b/src/main/java/com/roomfit/be/chat/application/dto/ChatRoomDTO.java
@@ -1,10 +1,13 @@
 package com.roomfit.be.chat.application.dto;
 
 import com.roomfit.be.chat.domain.ChatRoom;
+import com.roomfit.be.participation.application.dto.ParticipantDTO;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 public class ChatRoomDTO {
 
@@ -56,4 +59,34 @@ public class ChatRoomDTO {
         Long roomId;
     }
 
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DetailsResponse {
+
+        Long id;
+        String name;
+        String description;
+        String type;
+        String status;
+        Integer maxQuota;
+        Integer currentQuota;
+        String dormitory;
+        List<ParticipantDTO> participants;
+
+        public static DetailsResponse of(ChatRoom chatRoom, List<ParticipantDTO> participants) {
+            return DetailsResponse.builder()
+                    .id(chatRoom.getId())
+                    .name(chatRoom.getName())
+                    .description(chatRoom.getDescription())
+                    .type(chatRoom.getType().name())
+                    .status(chatRoom.getStatus().name())
+                    .maxQuota(chatRoom.getMaxQuota())
+                    .currentQuota(chatRoom.getCurrentQuota())
+                    .dormitory(chatRoom.getDormitory())
+                    .participants(participants)
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/roomfit/be/chat/infrastructure/aspect/MessageCountAspect.java
+++ b/src/main/java/com/roomfit/be/chat/infrastructure/aspect/MessageCountAspect.java
@@ -1,4 +1,4 @@
-    package com.roomfit.be.chat.infrastructure.aop;
+    package com.roomfit.be.chat.infrastructure.aspect;
 
     import com.roomfit.be.chat.application.dto.MessageDTO;
     import com.roomfit.be.chat.infrastructure.MessageRepository;

--- a/src/main/java/com/roomfit/be/global/config/RedisConfig.java
+++ b/src/main/java/com/roomfit/be/global/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.roomfit.be.global.config;
 
+import com.roomfit.be.auth.domain.AuthToken;
 import com.roomfit.be.auth.domain.VerificationCode;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -50,6 +51,20 @@ public class RedisConfig {
     public ReactiveRedisTemplate<String, VerificationCode> verificationCodeRedisTemplate(
             RedisConnectionFactory connectionFactory) {
         return reactiveRedisTemplate(connectionFactory, VerificationCode.class);
+    }
+
+    @Bean
+    @Qualifier("authTokenRedisTemplate")
+    public RedisTemplate<String, AuthToken> AuthTokenRedisTemplate(
+            RedisConnectionFactory connectionFactory) {
+
+        RedisTemplate<String, AuthToken> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new Jackson2JsonRedisSerializer<>(AuthToken.class));
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new Jackson2JsonRedisSerializer<>(AuthToken.class));
+        return template;
     }
 
     @Bean


### PR DESCRIPTION
## 🐛 연결 된 이슈
- #64 

## 📖 내용
채팅방의 기본 정보를 포함하도록 변경
#### 기존
```json
{
  "success": true,
  "message": "string",
  "data": {
   "participants": [
      {
        "id": 0,
        "nickname": "string",
        "college": "string"
      }
    ]
  }
}
```
#### 변경 된 응답 형식
```json
{
  "success": true,
  "message": "string",
  "data": {
    "id": 0,
    "name": "string",
    "description": "string",
    "type": "string",
    "status": "string",
    "maxQuota": 0,
    "currentQuota": 0,
    "dormitory": "string",
    "participants": [
      {
        "id": 0,
        "nickname": "string",
        "college": "string"
      }
    ]
  }
}
```