### PR TITLE
모든 사용자 조회 API에 설문 유무 포함 및 비밀번호 필드 제거

### DIFF
--- a/src/main/java/com/roomfit/be/user/application/dto/UserDTO.java
+++ b/src/main/java/com/roomfit/be/user/application/dto/UserDTO.java
@@ -34,22 +34,22 @@ public class UserDTO {
         private String nickname;
         private String email;
         private String role;
-        private String password;
         private String birth;
         private Integer studentId;
         private String college;
         private String gender;
+        private boolean isSurveyComplete;
         public static Response of(User user) {
             return Response.builder()
                     .id(user.getId())
                     .nickname(user.getNickname())
                     .email(user.getEmail())
                     .role(user.getRole().name())
-                    .password(user.getPassword())
                     .birth(user.getBirth())
                     .studentId(user.getStudentId())
                     .college(user.getCollege())
                     .gender(user.getGender().name())
+                    .isSurveyComplete(user.isSurveyComplete())
                     .build();
         }
     }

--- a/src/main/java/com/roomfit/be/user/domain/User.java
+++ b/src/main/java/com/roomfit/be/user/domain/User.java
@@ -75,4 +75,8 @@ public class User extends BaseEntity {
     public void completeSurvey() {
         this.stage = SurveyStage.POST_SURVEY;
     }
+
+    public boolean isSurveyComplete() {
+        return this.stage.name().equals(SurveyStage.POST_SURVEY.name());
+    }
 }


### PR DESCRIPTION
## 🐛 연결 된 이슈
- #74 

## 📖 내용
- User 도메인 내에 설문 유무를 판별하는 메소드 추가
- User 응답 DTO 에서 비밀번호 제거 및 설문 유무 판별 필드 추가